### PR TITLE
ci: ignore visual studio editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tmp/
 # Ignore code editor files
 .vscode/
 *.sublime-workspace
+.vs/
 
 # Ignore OS files
 .DS_Store


### PR DESCRIPTION
Developers using Visual Studio 2019 creates a .vs directory and should be ignored.