### PR TITLE
docs(cla): add Contributor License Agreement

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,21 +1,23 @@
 # CONTRIBUTOR LICENCE AGREEMENT
 
-version 1.00 / 01-12-2020 / document license: CC0
+version 1.00 / 01-12-2020
+
+This text of this document is licensed under the CC0 license.
 
 ---
 
-The {{NL Design System community and the supporting organisations}} (hereinafter: {{NL Design System}} would like to utilise the knowledge of third parties in developing digital resources that could contribute to {{design system stuff}} (hereinafter referred to collectively as: the Digital Resources).
+The State of the Netherlands, Ministry of the Interior and Kingdom Relations (hereinafter: the Ministry) and the NL Design System Community (hereinafter: the Community) would like to utilise the knowledge of third parties in developing digital resources that could contribute to a Design System for the public sector (hereinafter referred to collectively as: the Digital Resources).
 
 You (hereinafter: the Contributor) wish to contribute to the development of the Digital Resources, for example in the form of new or an adaptation of existing software, designs, documentation, digital files and/or other works to which intellectual property rights can attach (hereinafter: the Contributions).
 
-The purpose of this licence agreement is (i) to clarify the intellectual property rights to the Contributions and (ii) to enable {{NL Design System}} to use and publish the Contributions.
+The purpose of this licence agreement is (i) to clarify the intellectual property rights to the Contributions and (ii) to enable the Ministry and the Community to use and publish the Contributions.
 
 By accepting this licence agreement, the Contributor declares that he/she has read the terms and conditions of this licence agreement and is in agreement with these terms and conditions.
 
 ## Rights granted by the Contributor
 
-- The Contributor does not transfer any intellectual property rights relating to the Contributions to {{NL Design System}}.
-- The Contributor hereby grants {{NL Design System}} a perpetual, worldwide, non-exclusive, sublicensable, irrevocable and unrestricted right of use to the Contributions. This right of use pertains to all intellectual property rights that could attach to the Contributions, which in any event includes copyrights, trademark rights, database rights and patents.
+- The Contributor does not transfer any intellectual property rights relating to the Contributions to NL Design System.
+- The Contributor hereby grants the Ministry and the Community a perpetual, worldwide, non-exclusive, sublicensable, irrevocable and unrestricted right of use to the Contributions. This right of use pertains to all intellectual property rights that could attach to the Contributions, which in any event includes copyrights, trademark rights, database rights and patents.
 - The right of use to the Contributions in any event includes but is not limited to the right to:
   - use the Contributions, copies and adaptations thereof in any circumstances and for all usages;
   - publish the Contributions, copies and adaptations thereof;
@@ -27,28 +29,18 @@ By accepting this licence agreement, the Contributor declares that he/she has re
   - sublicense the Contributions (including copies and adaptations thereof and derivative works) to any third party under the terms and conditions of the most recent version of the European Union Public Licence (EUPL) or a 'compatible licence' within the meaning of the EUPL.
 - Those rights can be exercised on any media, supports and formats, whether now known or later invented, as far as the applicable law permits so.
 - The Contributor waives its right to exercise its immaterial rights to the extent permitted by applicable law in order to enable the effective exercise of the aforementioned licensed economic rights.
-- {{NL Design System}} does not owe the Contributor any fee for the right of use.
-- {{NL Design System}} is not obliged to use the Contributions.
+- the Ministry and the Community do not owe the Contributor any fee for the right of use.
+- the Ministry and the Community are not obliged to use the Contributions.
 
 ## Warranties by the Contributor
 
 - The Contributor grants the right of use to the Contributions on an ‘as is’ basis. The Contributor bears no responsibility for errors, defects and omissions in the Contributions.
-- The Contributor guarantees that the Contributions are his/her own work. The Contributor may not provide Contributions from third parties to {{NL Design System}}.
+- The Contributor guarantees that the Contributions are his/her own work. The Contributor may not provide Contributions from third parties to the Ministry and the Community.
 - The Contributor guarantees that he/she is legally entitled to grant the right of use referred to in clause 1. If the intellectual property rights to Contributions accrue to the Contributor’s employer, the Contributor hereby declares that he/she has received permission from his/her employer to grant the right of use referred to in clause 1.
-- The Contributor guarantees that he/she will not institute legal proceedings against {{NL Design System}} or third parties or suggest that such proceedings be instituted if they make use of the Contributions in accordance with this licence.
-- The Contributor guarantees that he/she will inform {{NL Design System}} if he/she has unexpectedly provided {{NL Design System}} with incorrect information in any way whatsoever.
+- The Contributor guarantees that he/she will not institute legal proceedings against the Ministry and the Community or third parties or suggest that such proceedings be instituted if they make use of the Contributions in accordance with this licence.
+- The Contributor guarantees that he/she will inform the Ministry and the Community if he/she has unexpectedly provided the Ministry and the Community with incorrect information in any way whatsoever.
 
 ## Remaining provisions
 
 - Dutch law applies to this licence agreement.
 - Exclusively the judge in The Hague is competent to hear disputes in connection with this licence agreement.
-
----
-
-Signature:
-
-Name:
-
-Email address:
-
-GitHub username:

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,54 @@
+# CONTRIBUTOR LICENCE AGREEMENT
+
+version 1.00 / 01-12-2020 / document license: CC0
+
+---
+
+The {{NL Design System community and the supporting organisations}} (hereinafter: {{NL Design System}} would like to utilise the knowledge of third parties in developing digital resources that could contribute to {{design system stuff}} (hereinafter referred to collectively as: the Digital Resources).
+
+You (hereinafter: the Contributor) wish to contribute to the development of the Digital Resources, for example in the form of new or an adaptation of existing software, designs, documentation, digital files and/or other works to which intellectual property rights can attach (hereinafter: the Contributions).
+
+The purpose of this licence agreement is (i) to clarify the intellectual property rights to the Contributions and (ii) to enable {{NL Design System}} to use and publish the Contributions.
+
+By accepting this licence agreement, the Contributor declares that he/she has read the terms and conditions of this licence agreement and is in agreement with these terms and conditions.
+
+## Rights granted by the Contributor
+
+- The Contributor does not transfer any intellectual property rights relating to the Contributions to {{NL Design System}}.
+- The Contributor hereby grants {{NL Design System}} a perpetual, worldwide, non-exclusive, sublicensable, irrevocable and unrestricted right of use to the Contributions. This right of use pertains to all intellectual property rights that could attach to the Contributions, which in any event includes copyrights, trademark rights, database rights and patents.
+- The right of use to the Contributions in any event includes but is not limited to the right to:
+  - use the Contributions, copies and adaptations thereof in any circumstances and for all usages;
+  - publish the Contributions, copies and adaptations thereof;
+  - reproduce the Contributions, copies and adaptations thereof;
+  - communicate to the public the Contributions, copies and adaptations thereof, including the right to make available or to display to the public the work or copies thereof and, where appropriate, to perform the work in public;
+  - distribute the Contributions, copies and adaptations thereof;
+  - lend and let out the Contributions, copies and adaptations thereof;
+  - modify the Contributions, copies and adaptations thereof and create derivative works;
+  - sublicense the Contributions (including copies and adaptations thereof and derivative works) to any third party under the terms and conditions of the most recent version of the European Union Public Licence (EUPL) or a 'compatible licence' within the meaning of the EUPL.
+- Those rights can be exercised on any media, supports and formats, whether now known or later invented, as far as the applicable law permits so.
+- The Contributor waives its right to exercise its immaterial rights to the extent permitted by applicable law in order to enable the effective exercise of the aforementioned licensed economic rights.
+- {{NL Design System}} does not owe the Contributor any fee for the right of use.
+- {{NL Design System}} is not obliged to use the Contributions.
+
+## Warranties by the Contributor
+
+- The Contributor grants the right of use to the Contributions on an ‘as is’ basis. The Contributor bears no responsibility for errors, defects and omissions in the Contributions.
+- The Contributor guarantees that the Contributions are his/her own work. The Contributor may not provide Contributions from third parties to {{NL Design System}}.
+- The Contributor guarantees that he/she is legally entitled to grant the right of use referred to in clause 1. If the intellectual property rights to Contributions accrue to the Contributor’s employer, the Contributor hereby declares that he/she has received permission from his/her employer to grant the right of use referred to in clause 1.
+- The Contributor guarantees that he/she will not institute legal proceedings against {{NL Design System}} or third parties or suggest that such proceedings be instituted if they make use of the Contributions in accordance with this licence.
+- The Contributor guarantees that he/she will inform {{NL Design System}} if he/she has unexpectedly provided {{NL Design System}} with incorrect information in any way whatsoever.
+
+## Remaining provisions
+
+- Dutch law applies to this licence agreement.
+- Exclusively the judge in The Hague is competent to hear disputes in connection with this licence agreement.
+
+---
+
+Signature:
+
+Name:
+
+Email address:
+
+GitHub username:

--- a/CLA.md
+++ b/CLA.md
@@ -12,7 +12,7 @@ You (hereinafter: the Contributor) wish to contribute to the development of the 
 
 The purpose of this licence agreement is (i) to clarify the intellectual property rights to the Contributions and (ii) to enable the Ministry and the Community to use and publish the Contributions.
 
-By accepting this licence agreement, the Contributor declares that he/she has read the terms and conditions of this licence agreement and is in agreement with these terms and conditions.
+By accepting this licence agreement, the Contributor declares that they have read the terms and conditions of this licence agreement and is in agreement with these terms and conditions.
 
 ## Rights granted by the Contributor
 
@@ -35,10 +35,10 @@ By accepting this licence agreement, the Contributor declares that he/she has re
 ## Warranties by the Contributor
 
 - The Contributor grants the right of use to the Contributions on an ‘as is’ basis. The Contributor bears no responsibility for errors, defects and omissions in the Contributions.
-- The Contributor guarantees that the Contributions are his/her own work. The Contributor may not provide Contributions from third parties to the Ministry and the Community.
-- The Contributor guarantees that he/she is legally entitled to grant the right of use referred to in clause 1. If the intellectual property rights to Contributions accrue to the Contributor’s employer, the Contributor hereby declares that he/she has received permission from his/her employer to grant the right of use referred to in clause 1.
-- The Contributor guarantees that he/she will not institute legal proceedings against the Ministry and the Community or third parties or suggest that such proceedings be instituted if they make use of the Contributions in accordance with this licence.
-- The Contributor guarantees that he/she will inform the Ministry and the Community if he/she has unexpectedly provided the Ministry and the Community with incorrect information in any way whatsoever.
+- The Contributor guarantees that the Contributions are their own work. The Contributor may not provide Contributions from third parties to the Ministry and the Community.
+- The Contributor guarantees that they are legally entitled to grant the right of use referred to in clause 1. If the intellectual property rights to Contributions accrue to the Contributor’s employer, the Contributor hereby declares that they have received permission from their employer to grant the right of use referred to in clause 1.
+- The Contributor guarantees that they will not institute legal proceedings against the Ministry and the Community or third parties or suggest that such proceedings be instituted if they make use of the Contributions in accordance with this licence.
+- The Contributor guarantees that they will inform the Ministry and the Community if they have unexpectedly provided the Ministry and the Community with incorrect information in any way whatsoever.
 
 ## Remaining provisions
 


### PR DESCRIPTION
Some parts of the text still need to be figured out, as marked by the `{{ fill in the blanks }}` regions.

Source:
https://github.com/minvws/nl-covid19-notification-app-coordination

The source document is provided under CC0 license, as agreed by the Landsadvocaat.