### PR TITLE
docs: add Dutch translation for Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.nl.md
+++ b/CODE_OF_CONDUCT.nl.md
@@ -1,0 +1,47 @@
+
+# Gedragscode voor Bijdragers
+
+## Onze belofte
+
+In het belang van het bevorderen van een open en welkome omgeving, beloven wij, de bijdragers en onderhouders, om het deelnemen in ons project en onze gemeenschap een intimidatie-vrije ervaring te maken voor iedereen. Dit onafhankelijk van leeftijd, lichaam, handicap, etniciteit, gender identiteit en uiting, ervaringsniveau, nationaliteit, persoonlijk voorkomen, ras, religie of seksuele indentiteit en oriëntatie.
+
+## Onze standaarden
+
+Voorbeelden van gedrag dat bijdraagt tot het creëren van een positieve omgeving
+omvat onder andere:
+
+* Gebruik van gastvrije en omvattende taal
+* Respectvol zijn ten aanzien van andere standpunten en ervaringen
+* Het accepteren van constructieve kritiek
+* Focussen op wat het beste is voor de gemeenschap
+* Empathisch zijn ten aanzien van andere deelnemers
+
+Voorbeelden van niet acceptabel gedrag bij deelnemers omvat:
+
+* Het gebruik van seksueel geladen taal of prenten, alsook ongewenst seksuele aandacht of avances
+* Trollen, beledigend/denigrerend commentaar en persoonlijke of politieke aanvallen
+* Publiek of privaat lastig vallen
+* Het publiceren van privéinformatie zoals een fysiek of electronisch adres zonder expliciete toestemming
+* Ander gedrag dat redelijkerwijs zou kunnen worden beschouwd als ongepast in een professionele omgeving
+
+## Onze verantwoordelijkheden
+
+Projectonderhouders zijn verantwoordelijk om klaarheid te scheppen met betrekking tot de standaarden van acceptabel gedrag en worden verwacht de passende en billijke corrigerende maatregelen te treffen als antwoord op vertoningen van niet acceptabel gedrag.
+
+Projectonderhouders hebben het recht en de verantwoordelijkheid om commentaar, commits, code, wiki edits, issues en andere contributies te verwijderen, te bewerken of af te keuren indien deze niet voldoen aan deze Gedragscode, of om tijdelijk of permanent zij te verbannen wiens gedrag als ongewenst, bedreigend, beledigend of schadelijk wordt geacht.
+
+## Bereik
+
+Deze Gedragscode geldt voor zowel binnen project ruimtes alsook in publieke ruimtes wanneer een individu het project of de gemeenschap vertegenwoordigd. Voorbeelden van vertegenwoordiging van een project of gemeenschap omvatten het gebruik van een officieel e-mailadres van het project, het posten via een officiële sociale media account, of het handelen als een aangestelde vertegenwoordiger op een online of offline event. Vertegenwoordiging
+van een project mag verder worden gedefinieerd door de projectonderhouders.
+
+## Handhaving
+
+Instanties van beledigend, storend of anders niet aanvaardbaar gedrag mag worden gerapporteerd aan de projectonderhouders die verantwoordelijk zijn voor handhaving via e-mail of Slack. Alle klachten zullen besproken en onderzocht worden en zullen resulteren in een antwoord dat nodig en passend wordt geacht al naargelang de situatie. Het project team is verplicht om vertrouwelijkheid te garanderen met betrekking tot de klager. Verdere details van specifiek handhavingsbeleid kan apart worden gepubliceerd.
+
+Projectonderhouders die de Gedragscode niet volgen of ter goeder trouw handhaven, kunnen tijdelijke of permanente repercussies opgelegd krijgen door overige leden van de projectleiding.
+
+## Attributie
+
+Deze Gedragscode is een  aangepaste versie van  de [Contributor Covenant](https://www.contributor-covenant.org),
+versie 1.4, beschikbaar op [https://www.contributor-covenant.org/nl/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/nl/version/1/4/code-of-conduct.html).


### PR DESCRIPTION
Added slightly modified 1.4 version of the Contributor Covenant Dutch translation of the code of conduct.

Modifications include minor typo fixes.