### PR TITLE
ci: rename GitHub Actions to avoid duplicate job name

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: Release & Deploy
+name: Continuous Delivery
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build-and-deploy:
+  continuous-delivery:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint & Test
+name: Continuous Integration
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build-and-deploy:
+  continuous-integration:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Fixes the configuration with a duplicate job name, which prevents us from correctly configuring the `lint` and `test` scripts are requirement before merging a branch in GitHub.