### PR TITLE
docs: relink status-badge figma file

### DIFF
--- a/packages/nl-design-system-unstable/status-badge-component/stories/getStorySetup.js
+++ b/packages/nl-design-system-unstable/status-badge-component/stories/getStorySetup.js
@@ -36,7 +36,7 @@ export default (Template) => {
     ],
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/thNg88CEm4XU4Pm9K2V0m2/component-badge-status-badge',
+      url: 'https://www.figma.com/file/gqQhMe3gj4YlC6JrZOWiCv/Components?node-id=102%3A200',
     },
     status: 'IN DEVELOPMENT',
     notes: { UX: README, Content: contentGuidelines },


### PR DESCRIPTION
Changed link to Figma file. Previously each component was a single Figma file, in hindsight it will be better to combine all components in a single file.