### PR TITLE
ci: add build on schedule and manual build option

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0-23 * * *"
 
 jobs:
   continuous-delivery:


### PR DESCRIPTION
Use a schedule to build storybook each hour to launch any latests `nl-design-system/documentatie#production` docs 
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule

And add a manual trigger
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch