### PR TITLE
ci: deploy to GitHub Pages branch too

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,3 +35,9 @@ jobs:
           slot-name: "production"
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           package: .
+
+      - name: Continuous Deployment to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.3
+        with:
+          branch: gh-pages
+          folder: dist/storybook


### PR DESCRIPTION
Would be nice to have a backup in Git of the static rendering of Storybook.